### PR TITLE
store: use a more optimized get method in scc.rs

### DIFF
--- a/src/stores/scc.rs
+++ b/src/stores/scc.rs
@@ -40,10 +40,7 @@ impl KVMapHandle for SccHashMap {
     }
 
     fn get(&mut self, key: &[u8]) -> Option<Box<[u8]>> {
-        match self.0.get(key) {
-            Some(r) => Some(r.clone()),
-            None => None,
-        }
+        self.0.read(key, |_, r| r.clone())
     }
 
     fn delete(&mut self, key: &[u8]) {

--- a/src/stores/scc.rs
+++ b/src/stores/scc.rs
@@ -34,9 +34,7 @@ impl KVMap for SccHashMap {
 
 impl KVMapHandle for SccHashMap {
     fn set(&mut self, key: &[u8], value: &[u8]) {
-        if let Err(_) = self.0.insert(key.into(), value.into()) {
-            assert!(self.0.update(key, |_, v| *v = value.into()).is_some());
-        }
+        let _result = self.0.insert(key.into(), value.into());
     }
 
     fn get(&mut self, key: &[u8]) -> Option<Box<[u8]>> {

--- a/src/stores/scc.rs
+++ b/src/stores/scc.rs
@@ -34,7 +34,14 @@ impl KVMap for SccHashMap {
 
 impl KVMapHandle for SccHashMap {
     fn set(&mut self, key: &[u8], value: &[u8]) {
-        let _result = self.0.insert(key.into(), value.into());
+        match self.0.entry(key.into()) {
+            scc::hash_map::Entry::Occupied(mut o) => {
+                *o.get_mut() = value.into();
+            }
+            scc::hash_map::Entry::Vacant(v) => {
+                v.insert_entry(value.into());
+            }
+        }
     }
 
     fn get(&mut self, key: &[u8]) -> Option<Box<[u8]>> {


### PR DESCRIPTION
Remove the assertion to avoid double-reserving the same entry.

Replace scc::HashMap::get with scc::HashMap::read as scc::HashMap::get acquires exclusive locks for entry modification whereas scc::HashMap::read acquires shared locks and is more suitable for read-heavy workloads.

@nerdroychan Hi, nice to meet you. This crate looks great for measuring performance of various store types! I figure that the `scc` adaptor uses a sub-optimal method for `get`, so this PR replaces it with a more optimal method for read-heavy workloads.